### PR TITLE
feat: allow custom verses

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const STORAGE_KEYS = {
   lastShown: "fp_last_shown",      // yyyy-mm-dd
   snoozeUntil: "fp_snooze_until",  // ISO timestamp
   favorites: "fp_favorites",       // array of verse objects
+  customVerses: "fp_custom_verses", // user-added verses
 };
 const MODAL_SNOOZE_MIN = 10;
 
@@ -128,6 +129,14 @@ function importFavorites(file) {
   reader.readAsText(file);
 }
 
+// ===== Custom Verses =====
+function getCustomVerses() { return loadJSON(STORAGE_KEYS.customVerses, []); }
+function addCustomVerse(v) {
+  const arr = getCustomVerses();
+  arr.push(v);
+  saveJSON(STORAGE_KEYS.customVerses, arr);
+}
+
 // ===== Rendering =====
 function escapeHtml(s){return String(s).replace(/[&<>"']/g,c=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));}
 function renderVerse(v) {
@@ -138,6 +147,16 @@ function renderVerse(v) {
   $("#modal-text").textContent = v.text;
   $("#time-label").textContent = new Date().toLocaleString();
   renderFavButton();
+}
+function renderVerseList() {
+  const list = $("#verse-list");
+  if (!list) return;
+  list.innerHTML = "";
+  VERSES.forEach(v => {
+    const li = document.createElement("li");
+    li.innerHTML = `<strong>${escapeHtml(v.reference)}</strong><br>${escapeHtml(v.text)}`;
+    list.appendChild(li);
+  });
 }
 function showModal() {
   const dlg = $("#verse-modal");
@@ -230,10 +249,12 @@ async function init() {
     console.error("Failed to load verses.json");
     VERSES = [];
   }
+  VERSES = [...VERSES, ...getCustomVerses()];
 
   // Render today's verse immediately
   const v = pickVerseForDate(todayKey());
   if (v) renderVerse(v);
+  renderVerseList();
 
   // Apply settings
   document.getElementById("year").textContent = new Date().getFullYear();
@@ -247,6 +268,20 @@ async function init() {
   $("#btn-open-settings").addEventListener("click", ()=> $("#settings").showModal());
   $("#btn-open-favs").addEventListener("click", ()=> $("#favorites").showModal());
   $("#btn-close-favs").addEventListener("click", ()=> $("#favorites").close());
+  $("#btn-open-add").addEventListener("click", ()=> $("#add-verse").showModal());
+  $("#btn-cancel-add").addEventListener("click", ()=> $("#add-verse").close());
+  $("#add-verse-form").addEventListener("submit", (e)=>{
+    e.preventDefault();
+    const ref = $("#new-verse-ref").value.trim();
+    const text = $("#new-verse-text").value.trim();
+    if (!ref || !text) return;
+    const v = { id: `c${Date.now()}`, reference: ref, text };
+    addCustomVerse(v);
+    VERSES.push(v);
+    renderVerseList();
+    e.target.reset();
+    $("#add-verse").close();
+  });
 
   $("#btn-next").addEventListener("click", ()=> renderVerse(randomVerse(CURRENT?.id)));
 

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
     <nav class="nav">
       <button id="btn-open-settings" class="btn ghost">Settings</button>
       <button id="btn-open-favs" class="btn ghost">Favorites</button>
+      <button id="btn-open-add" class="btn ghost">Add Verse</button>
       <a class="btn primary" href="#" id="btn-show-now" aria-label="Show today's verse now">Today’s Verse</a>
     </nav>
   </header>
@@ -41,6 +42,11 @@
         <span id="today-label">Today:</span>
         <span id="time-label" class="muted"></span>
       </div>
+    </section>
+
+    <section class="card" id="all-verses">
+      <h2>All Verses</h2>
+      <ul id="verse-list" class="list"></ul>
     </section>
 
     <section class="card info">
@@ -116,6 +122,25 @@
         <button class="btn primary" id="btn-close-favs">Close</button>
       </div>
     </div>
+  </dialog>
+
+  <!-- Add Verse -->
+  <dialog id="add-verse" class="modal" aria-label="Add Verse">
+    <form id="add-verse-form" class="modal-content">
+      <h3>Add Verse</h3>
+      <label class="field">
+        <span>Reference</span>
+        <input id="new-verse-ref" required />
+      </label>
+      <label class="field">
+        <span>Text</span>
+        <textarea id="new-verse-text" required></textarea>
+      </label>
+      <menu class="modal-actions">
+        <button class="btn" type="button" id="btn-cancel-add">Cancel</button>
+        <button class="btn primary" id="btn-save-verse">Save</button>
+      </menu>
+    </form>
   </dialog>
 
   <footer class="footer">


### PR DESCRIPTION
## Summary
- add "Add Verse" dialog and button
- persist custom verses and list them on the front page
- render verse list and hook up handlers for creating custom verses

## Testing
- `node --version`
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b128b06578832987a198fea4c51415