### PR TITLE
Separate all verses page and simplify verse actions

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,7 +8,6 @@ const STORAGE_KEYS = {
   lastShown: "fp_last_shown",      // yyyy-mm-dd
   snoozeUntil: "fp_snooze_until",  // ISO timestamp
   favorites: "fp_favorites",       // array of verse objects
-  customVerses: "fp_custom_verses", // user-added verses
 };
 const MODAL_SNOOZE_MIN = 10;
 
@@ -134,14 +133,6 @@ function importFavorites(file) {
   reader.readAsText(file);
 }
 
-// ===== Custom Verses =====
-function getCustomVerses() { return loadJSON(STORAGE_KEYS.customVerses, []); }
-function addCustomVerse(v) {
-  const arr = getCustomVerses();
-  arr.push(v);
-  saveJSON(STORAGE_KEYS.customVerses, arr);
-}
-
 // ===== Rendering =====
 function escapeHtml(s){return String(s).replace(/[&<>"']/g,c=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));}
 function renderVerse(v) {
@@ -254,7 +245,6 @@ async function init() {
     console.error("Failed to load verses.json");
     VERSES = [];
   }
-  VERSES = [...VERSES, ...getCustomVerses()];
 
   // Render today's verse immediately
   const v = pickVerseForDate(todayKey());
@@ -273,24 +263,7 @@ async function init() {
   $("#btn-open-settings").addEventListener("click", ()=> $("#settings").showModal());
   $("#btn-open-favs").addEventListener("click", ()=> $("#favorites").showModal());
   $("#btn-close-favs").addEventListener("click", ()=> $("#favorites").close());
-  $("#btn-open-add").addEventListener("click", ()=> $("#add-verse").showModal());
-  $("#btn-cancel-add").addEventListener("click", ()=> $("#add-verse").close());
-  $("#add-verse-form").addEventListener("submit", (e)=>{
-    e.preventDefault();
-    const ref = $("#new-verse-ref").value.trim();
-    const text = $("#new-verse-text").value.trim();
-    if (!ref || !text) return;
-    const v = { id: `c${Date.now()}`, reference: ref, text };
-    addCustomVerse(v);
-    VERSES.push(v);
-    renderVerseList();
-    e.target.reset();
-    $("#add-verse").close();
-  });
-
-  $("#btn-next").addEventListener("click", ()=> renderVerse(randomVerse(CURRENT?.id)));
-
-  $("#modal-next").addEventListener("click", ()=> renderVerse(randomVerse(CURRENT?.id)));
+  $("#btn-get-verse").addEventListener("click", ()=> renderVerse(randomVerse(CURRENT?.id)));
 
   $("#btn-share").addEventListener("click", shareCurrent);
   $("#btn-copy").addEventListener("click", copyCurrent);

--- a/index.html
+++ b/index.html
@@ -21,7 +21,8 @@
     <nav class="nav">
       <button id="btn-open-settings" class="btn ghost">Settings</button>
       <button id="btn-open-favs" class="btn ghost">Favorites</button>
-      <button id="btn-open-add" class="btn ghost">Add Verse</button>
+      <a class="btn ghost" href="verses.html">All Verses</a>
+      <button id="btn-get-verse" class="btn ghost">Get New Verse</button>
       <a class="btn primary" href="#" id="btn-show-now" aria-label="Show today's verse now">Today’s Verse</a>
     </nav>
   </header>
@@ -34,9 +35,6 @@
         <button id="btn-share" class="btn">Share</button>
         <button id="btn-copy" class="btn">Copy</button>
         <button id="btn-fav" class="btn">❤ Favorite</button>
-
-        <button id="btn-next" class="btn ghost">New Verse</button>
-
       </div>
       <div class="meta">
         <span id="today-label">Today:</span>
@@ -44,10 +42,6 @@
       </div>
     </section>
 
-    <section class="card" id="all-verses">
-      <h2>All Verses</h2>
-      <ul id="verse-list" class="list"></ul>
-    </section>
 
     <section class="card info">
       <h2>How it works2</h2>
@@ -69,9 +63,6 @@
         <button id="modal-share" class="btn">Share</button>
         <button id="modal-copy" class="btn">Copy</button>
         <button id="modal-fav" class="btn">❤ Favorite</button>
-
-        <button id="modal-next" class="btn ghost">New Verse</button>
-
         <button id="modal-snooze" class="btn ghost">Snooze 10 min</button>
         <button id="modal-close" class="btn primary">Close</button>
       </div>
@@ -124,24 +115,6 @@
     </div>
   </dialog>
 
-  <!-- Add Verse -->
-  <dialog id="add-verse" class="modal" aria-label="Add Verse">
-    <form id="add-verse-form" class="modal-content">
-      <h3>Add Verse</h3>
-      <label class="field">
-        <span>Reference</span>
-        <input id="new-verse-ref" required />
-      </label>
-      <label class="field">
-        <span>Text</span>
-        <textarea id="new-verse-text" required></textarea>
-      </label>
-      <menu class="modal-actions">
-        <button class="btn" type="button" id="btn-cancel-add">Cancel</button>
-        <button class="btn primary" id="btn-save-verse">Save</button>
-      </menu>
-    </form>
-  </dialog>
 
   <footer class="footer">
     © <span id="year"></span> FaithPing • PWA POC • <a href="privacy.html">Privacy</a>

--- a/service-worker.js
+++ b/service-worker.js
@@ -6,8 +6,10 @@ const CACHE = `faithping-${VERSION}`;
 const ASSETS = [
   "./",
   "./index.html",
+  "./verses.html",
   "./styles.css",
   "./app.js",
+  "./verses.js",
   "./verses.json",
   "./manifest.webmanifest",
   "./icons/icon-192.png",

--- a/verses.html
+++ b/verses.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>FaithPing — All Verses</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#5B3EBA" />
+  <meta name="description" content="FaithPing PWA — all verses list." />
+  <link rel="manifest" href="manifest.webmanifest">
+  <link rel="icon" href="icons/icon-192.png" sizes="192x192">
+  <link rel="apple-touch-icon" href="icons/icon-192.png">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">
+      <img src="icons/logo.svg" alt="" class="logo" />
+      <span class="brand-name">FaithPing POC</span>
+      <small class="tag">POC</small>
+    </div>
+    <nav class="nav">
+      <a class="btn ghost" href="index.html">Home</a>
+    </nav>
+  </header>
+
+  <main class="container">
+    <section class="card" id="all-verses">
+      <h2>All Verses</h2>
+      <ul id="verse-list" class="list"></ul>
+    </section>
+  </main>
+
+  <footer class="footer">
+    © <span id="year"></span> FaithPing • PWA POC • <a href="privacy.html">Privacy</a>
+  </footer>
+
+  <script src="verses.js" defer></script>
+</body>
+</html>

--- a/verses.js
+++ b/verses.js
@@ -1,0 +1,25 @@
+function escapeHtml(s){return String(s).replace(/[&<>"']/g,c=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));}
+
+async function loadVerses() {
+  const list = document.getElementById('verse-list');
+  try {
+    const res = await fetch('verses.json', { cache: 'no-store' });
+    const verses = await res.json();
+    verses.forEach(v => {
+      const li = document.createElement('li');
+      li.innerHTML = `<strong>${escapeHtml(v.reference)}</strong><br>${escapeHtml(v.text)}`;
+      list.appendChild(li);
+    });
+  } catch {
+    list.innerHTML = '<li>Failed to load verses.</li>';
+  }
+}
+
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('./service-worker.js').catch(()=>{});
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('year').textContent = new Date().getFullYear();
+  loadVerses();
+});


### PR DESCRIPTION
## Summary
- Move "All Verses" list to new `verses.html` and add supporting `verses.js`
- Replace add verse flow with "Get New Verse" button and remove per-verse new-verse controls
- Update service worker cache list for new assets

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`
- `node --check verses.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1305ccecc8329b0ff1a4633f18618